### PR TITLE
Support implementing Symbol-based EcmaScript protocols like Iterable

### DIFF
--- a/Sources/NodeAPI/NodeIterator.swift
+++ b/Sources/NodeAPI/NodeIterator.swift
@@ -1,0 +1,50 @@
+extension Sequence where Element: NodeValueConvertible {
+    @NodeActor public func nodeIterator() -> NodeIterator {
+        NodeIterator(self.lazy.map { $0 as NodeValueConvertible }.makeIterator())
+    }
+}
+
+public final class NodeIterator: NodeClass {
+    public struct Result: NodeValueConvertible, NodeValueCreatable {
+        public typealias ValueType = NodeObject
+
+        let value: NodeValueConvertible?
+        let done: Bool?
+
+        public func nodeValue() throws -> any NodeValue {
+            let obj = try NodeObject()
+            if let value = value {
+                try obj["value"].set(to: value)
+            }
+            if let done = done {
+                try obj["done"].set(to: done)
+            }
+            return obj
+        }
+
+        public static func from(_ value: ValueType) throws -> Self {
+            Self(
+                value: try value.get("value"),
+                done: try value.get("done").as(Bool.self)
+            )
+        }
+    }
+
+    public static let properties: NodeClassPropertyList = [
+        "next": NodeMethod(next),
+    ]
+
+    private var iterator: any IteratorProtocol<NodeValueConvertible>
+    public init(_ iterator: any IteratorProtocol<NodeValueConvertible>) {
+        self.iterator = iterator
+    }
+
+    public func next() -> Result {
+      if let value = iterator.next() {
+        return Result(value: value, done: false)
+      } else {
+        return Result(value: nil, done: true)
+      }
+    }
+}
+

--- a/Sources/NodeAPI/NodeSymbol.swift
+++ b/Sources/NodeAPI/NodeSymbol.swift
@@ -1,10 +1,39 @@
 @_implementationOnly import CNodeAPI
 
 public final class NodeSymbol: NodePrimitive, NodeName {
-
     @_spi(NodeAPI) public let base: NodeValueBase
     @_spi(NodeAPI) public init(_ base: NodeValueBase) {
         self.base = base
+    }
+  
+    public static func global(for name: String) throws -> NodeSymbol {
+        let ctx = NodeContext.current
+        let env = ctx.environment
+        let symbol = try env.global.Symbol.for(name)
+        if let nonNullSymbol = try symbol.nodeValue().as(NodeSymbol.self) {
+            return nonNullSymbol
+        } else {
+            throw NodeAPIError(.genericFailure, message: "globalThis.Symbol.for('\(name)') is not a symbol")
+        }
+    }
+
+    public static func deferredGlobal(for name: String) -> NodeDeferredName {
+        NodeDeferredName { try global(for: name) }
+    }
+  
+    public static func wellKnown(propertyName name: String) throws -> NodeSymbol {
+        let ctx = NodeContext.current
+        let env = ctx.environment
+        let property = try env.global.Symbol[name].as(NodeSymbol.self)
+        if let property = property {
+            return property
+        } else {
+            throw NodeAPIError(.genericFailure, message: "globalThis.Symbol.\(name) is not a symbol")
+        }
+    }
+
+    public static func deferredWellKnown(propertyName name: String) -> NodeDeferredName {
+        NodeDeferredName { try wellKnown(propertyName: name) }
     }
 
     public init(description: String? = nil) throws {
@@ -15,5 +44,14 @@ public final class NodeSymbol: NodePrimitive, NodeName {
         try env.check(napi_create_symbol(env.raw, descRaw, &result))
         self.base = NodeValueBase(raw: result, in: ctx)
     }
+}
 
+extension NodeSymbol {
+    /// Allows implementing the Iterable protocol for an object.
+    /// This method is called by the `for-of` statement or destructuring like `[...obj]`.
+    public static var iterator: NodeDeferredName { deferredWellKnown(propertyName: "iterator") }
+
+    /// This symbol allows customizing how NodeJS formats objects in console.log.
+    /// See https://nodejs.org/api/util.html#custom-inspection-functions-on-objects
+    public static var utilInspectCustom: NodeDeferredName { deferredGlobal(for: "nodejs.util.inspect.custom")}
 }

--- a/Sources/NodeAPI/NodeValue.swift
+++ b/Sources/NodeAPI/NodeValue.swift
@@ -116,6 +116,22 @@ public struct NodeDeferredValue: NodeValueConvertible, Sendable {
     }
 }
 
+// Utility for APIs that take NodeValueConvertible: useful when you
+// want to defer NodeValue creation to the API, for example for
+// accessing global or well-known Symbols.
+public struct NodeDeferredName: NodeValueConvertible, Sendable, NodeName {
+    let wrapper: @Sendable @NodeActor () throws -> NodeValue
+
+    // thread-safe
+    public init(_ wrapper: @escaping @Sendable @NodeActor () throws -> NodeValue) {
+        self.wrapper = wrapper
+    }
+
+    @NodeActor public func nodeValue() throws -> NodeValue {
+        try wrapper()
+    }
+}
+
 public protocol AnyNodeValueCreatable {
     @NodeActor static func from(_ value: NodeValue) throws -> Self?
 }

--- a/Sources/NodeAPI/NodeValue.swift
+++ b/Sources/NodeAPI/NodeValue.swift
@@ -182,13 +182,21 @@ extension NodeCallable {
     @discardableResult
     public func dynamicallyCall(withArguments args: [NodeValueConvertible]) throws -> AnyNodeValue {
         guard let fn = try self.as(NodeFunction.self) else {
-            throw NodeAPIError(.functionExpected, message: "Cannot call a non-function")
+            throw NodeAPIError(.functionExpected, message: "Cannot call a non-function: \(try debugDescription())")
         }
         return try fn.call(on: receiver, args)
     }
 
     public var new: NodeCallableConstructor {
         NodeCallableConstructor(callable: self)
+    }
+
+    internal func debugDescription() throws -> String {
+        let actual = "\(try self.nodeValue()) (\(self))"
+        if let dynamicProperty = self as? NodeObject.DynamicProperty {
+            return "\(receiver).\(dynamicProperty.key) is \(actual)"
+        }
+        return "is \(actual)"
     }
 }
 
@@ -198,7 +206,7 @@ extension NodeCallable {
     let callable: NodeCallable
     public func dynamicallyCall(withArguments args: [NodeValueConvertible]) throws -> NodeObject {
         guard let fn = try callable.as(NodeFunction.self) else {
-            throw NodeAPIError(.functionExpected, message: "Cannot call a non-function")
+            throw NodeAPIError(.functionExpected, message: "Cannot call a non-function as constructor: \(try callable.debugDescription())")
         }
         return try fn.construct(withArguments: args)
     }

--- a/Sources/NodeAPI/Sugar.swift
+++ b/Sources/NodeAPI/Sugar.swift
@@ -199,3 +199,7 @@ public macro NodeMethod(_: NodePropertyAttributes = .defaultMethod)
 @attached(peer, names: prefixed(`$`))
 public macro NodeProperty(_: NodePropertyAttributes = .defaultProperty)
     = #externalMacro(module: "NodeAPIMacros", type: "NodePropertyMacro")
+
+@attached(peer, names: prefixed(`$`))
+public macro NodeName(_: NodeName)
+    = #externalMacro(module: "NodeAPIMacros", type: "NodeNameMacro")

--- a/Sources/NodeAPIMacros/Diagnostics.swift
+++ b/Sources/NodeAPIMacros/Diagnostics.swift
@@ -37,4 +37,8 @@ extension DiagnosticMessage where Self == NodeDiagnosticMessage {
     static var expectedInit: Self {
         .init("@NodeConstructor can only be applied to an initializer")
     }
+
+    static var expectedName: Self {
+        .init("@NodeName must have a name provided")
+    }
 }

--- a/Sources/NodeAPIMacros/NodeClassMacro.swift
+++ b/Sources/NodeAPIMacros/NodeClassMacro.swift
@@ -31,9 +31,11 @@ struct NodeClassMacro: ExtensionMacro {
                     } else {
                         nil as TokenSyntax?
                     }
+                
                 if let identifier = identifier?.trimmed {
+                    let key = member.decl.attributes?.findAttribute(named: "NodeName")?.nodeAttributes ?? "\(literal: identifier.text)" as ExprSyntax
                     DictionaryElementSyntax(
-                        key: "\(literal: identifier.text)" as ExprSyntax,
+                        key: key,
                         value: "$\(identifier)" as ExprSyntax
                     )
                 }

--- a/Sources/NodeAPIMacros/NodeNameMacro.swift
+++ b/Sources/NodeAPIMacros/NodeNameMacro.swift
@@ -1,0 +1,18 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+struct NodeNameMacro: PeerMacro {
+    static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let _ = node.nodeAttributes else {
+            context.diagnose(.init(node: Syntax(node), message: .expectedName))
+            return []
+        }
+
+        // Processed by NodeClassMacro.
+        return []
+    }
+}

--- a/Sources/NodeAPIMacros/Plugin.swift
+++ b/Sources/NodeAPIMacros/Plugin.swift
@@ -8,5 +8,6 @@ import SwiftSyntaxMacros
         NodeConstructorMacro.self,
         NodeClassMacro.self,
         NodeModuleMacro.self,
+        NodeNameMacro.self,
     ]
 }

--- a/Sources/NodeAPIMacros/SyntaxUtils.swift
+++ b/Sources/NodeAPIMacros/SyntaxUtils.swift
@@ -1,14 +1,31 @@
 import SwiftSyntax
 
-extension AttributeListSyntax {
-    func hasAttribute(named name: String) -> Bool {
-        contains {
-            if case let .attribute(value) = $0 {
-                value.attributeName.as(IdentifierTypeSyntax.self)?.name.trimmed.text == name
-            } else {
-                false
-            }
+extension DeclSyntax {
+    var attributes: AttributeListSyntax? {
+        if let function = self.as(FunctionDeclSyntax.self) {
+            function.attributes
+        } else if let property = self.as(VariableDeclSyntax.self) {
+            property.attributes
+        } else {
+            nil
         }
+    }
+}
+
+extension AttributeListSyntax {
+    func findAttribute(named name: String) -> AttributeSyntax? {
+        lazy.compactMap { 
+            if case let .attribute(value) = $0 {
+                if value.attributeName.as(IdentifierTypeSyntax.self)?.name.trimmed.text == name {
+                    return value
+                }
+            }
+            return nil
+        }.first
+    }
+
+    func hasAttribute(named name: String) -> Bool {
+        findAttribute(named: name) != nil
     }
 }
 

--- a/Tests/NodeAPIMacrosTests/NodeClassMacroTests.swift
+++ b/Tests/NodeAPIMacrosTests/NodeClassMacroTests.swift
@@ -62,6 +62,42 @@ final class NodeClassMacroTests: XCTestCase {
         }
     }
 
+    func testCustomName() {
+        assertMacro {
+            #"""
+            @NodeClass final class Foo {
+                @NodeName("q")
+                @NodeProperty var x = 5
+                @NodeName(NodeSymbol.someGlobalSymbol)
+                @NodeProperty var y = 6
+                var z = 7
+
+                @NodeMethod func foo() {}
+                func bar() {}
+                @NodeMethod func baz() {}
+            }
+            """#
+        } expansion: {
+            """
+            final class Foo {
+                @NodeName("q")
+                @NodeProperty var x = 5
+                @NodeName(NodeSymbol.someGlobalSymbol)
+                @NodeProperty var y = 6
+                var z = 7
+
+                @NodeMethod func foo() {}
+                func bar() {}
+                @NodeMethod func baz() {}
+            }
+
+            extension Foo {
+                @NodeActor public static let properties: NodeClassPropertyList = ["q": $x, NodeSymbol.someGlobalSymbol: $y, "foo": $foo, "baz": $baz]
+            }
+            """
+        }
+    }
+
     func testNonClass() {
         assertMacro {
             #"""
@@ -98,6 +134,7 @@ final class NodeClassMacroTests: XCTestCase {
                 @NodeProperty(.enumerable) var y = "hello"
                 var z = 7
 
+                @NodeName("longerFooName")
                 @NodeMethod func foo(_ x: String) async throws {
                     throw SomeError(x)
                 }
@@ -157,7 +194,7 @@ final class NodeClassMacroTests: XCTestCase {
             }
 
             extension Foo {
-                @NodeActor public static let properties: NodeClassPropertyList = ["x": $x, "y": $y, "foo": $foo, "baz": $baz]
+                @NodeActor public static let properties: NodeClassPropertyList = ["x": $x, "y": $y, "longerFooName": $foo, "baz": $baz]
             }
             """#
         }

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,8 @@ const fs = require("fs").promises;
 const builder = require("../lib/builder");
 const { spawnSync } = require("child_process");
 
+const CLEAN = process.env.CLEAN && process.env.CLEAN !== "0"
+
 process.chdir(__dirname);
 
 function usage() {
@@ -41,7 +43,7 @@ async function runAll() {
     switch (command) {
         case "all":
             if (process.argv.length > 3) usage();
-            await builder.clean();
+            if (CLEAN || CLEAN === undefined) await builder.clean();
             await runAll();
             break;
         case "_suite":
@@ -50,7 +52,7 @@ async function runAll() {
         case "suite":
             if (process.argv.length !== 4) usage();
             const suite = process.argv[3];
-            if (!isChild) await builder.clean();
+            if (!isChild && CLEAN) await builder.clean();
             await runSuite(suite, isChild);
             break;
         default:

--- a/test/suites/Test/Test.swift
+++ b/test/suites/Test/Test.swift
@@ -58,4 +58,22 @@ final class File: NodeClass {
     }
 }
 
-#NodeModule(exports: ["File": File.deferredConstructor])
+final class SomeIterable: NodeClass {
+    typealias Element = String
+  
+    static let properties: NodeClassPropertyList = [
+        NodeSymbol.iterator: NodeMethod(nodeIterator),
+    ]
+
+    static let construct = NodeConstructor(SomeIterable.init(_:))
+    init(_ args: NodeArguments) throws { }
+
+    private let values: [String] = ["one", "two", "three"]
+  
+    func nodeIterator() throws -> NodeIterator {
+        values.nodeIterator()
+    }
+
+}
+
+#NodeModule(exports: ["File": File.deferredConstructor, "SomeIterable": SomeIterable.deferredConstructor])

--- a/test/suites/Test/index.js
+++ b/test/suites/Test/index.js
@@ -1,6 +1,6 @@
 const assert = require("assert");
 
-const { File } = require("../../.build/Test.node");
+const { File, SomeIterable } = require("../../.build/Test.node");
 
 assert.strictEqual(File.default().filename, "default.txt")
 
@@ -23,3 +23,13 @@ file.unlink();
 assert.strictEqual(file.reply("hi"), "You said hi");
 assert.strictEqual(file.reply(null), "You said nothing");
 assert.strictEqual(file.reply(undefined), "You said nothing");
+
+const iterable = new SomeIterable()
+const expected = ["one", "two", "three"]
+assert.deepStrictEqual(Array.from(iterable), expected)
+assert.deepStrictEqual([...iterable], expected)
+let index = 0
+for (const item of iterable) {
+    assert.strictEqual(item, expected[index])
+    index++
+}


### PR DESCRIPTION
This adds a set of features that allow Swift developers to implement protocols using Symbols, like [Iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol):

- Add helpers to `NodeSymbol` to access well-know symbols like `Symbol.iterator`, or the global symbol registry like `Symbol.for("user.land.protocol")`.
- `@NodeName(replacementName)` renames members exposed with `@NodeClass` + `@NodeProperty` or `@NodeMethod`. To implement a symbol-based protocol, pass the symbol as the replacementName.
- Implement `NodeIterator` class to support the Iterable protocol. An example iterable is included in an integration test.

Individual commits have some more details.

Discussion points:

- Should the renaming functionality `@NodeName` be better as a parameter for the existing `@NodeMethod` / `@NodeProperty` macros? It was easier to implement as a new macro for me because I'm new to Swift.
- I avoided using macros to implement `NodeIterator` since I didn't see other uses within the library. Should I convert that class to a `@NodeClass` macro? Since there's only one method exposed, it's not much difference in code size in this instance.
- The `NodeIterator` class is used for supporting Swift developers writing Iterable classes to Node, not for consuming Node iterators in Swift, although that could also be useful as well. Should this implementation do both? Or is this kind of thing out of scope for the node-swift library?
- Code style: I tried to follow four-space indents as best I could. Is there an auto-formatting setup you use? My editor tried its best to really mess things up, and it would be easier to contribute if there was some `swift-format` or `swiftformat` tool set up.

See the commit messages for more details.