### PR TITLE
Add globalDefaultQueue

### DIFF
--- a/Sources/NodeAPI/NodeActor.swift
+++ b/Sources/NodeAPI/NodeActor.swift
@@ -30,10 +30,20 @@ private final class NodeExecutor: SerialExecutor {
         // NodeExecutor.enqueue is invoked with the same isolation as the caller,
         // which means we can simply read out the TaskLocal value to obtain
         // this.
-        let target = NodeActor.target
+        //
+        // If there is no task-local value, try the global default, which is saved
+        // the first time we enter a Node context.
 
-        guard let q = target?.queue else {
-            nodeFatalError("There is no target NodeAsyncQueue associated with this Task")
+        let q: NodeAsyncQueue
+        if let target = NodeActor.target {
+            q = target.queue
+        } else if let globalQueue = NodeAsyncQueue.globalDefaultQueue {
+            q = globalQueue
+        } else {
+            nodeFatalError("""
+            There is no target NodeAsyncQueue associated with this Task, \
+            and there is no global default queue.
+            """)
         }
 
         let ref = self.asUnownedSerialExecutor()

--- a/test/suites/Integration/Integration.swift
+++ b/test/suites/Integration/Integration.swift
@@ -55,6 +55,12 @@ final class CleanupHandler: Sendable {
         try print(Node.run(script: "1+1"))
     }
 
+    // this should run on the default global NodeAsyncQueue
+    Task.detached { @Sendable @NodeActor in
+        try await Task.sleep(nanoseconds: 1 * NSEC_PER_SEC)
+        try print("Detached 1+1 = \(Node.run(script: "1+1"))")
+    }
+
     let promise = try NodePromise {
         try await Task.sleep(nanoseconds: 2 * NSEC_PER_SEC)
         return 5


### PR DESCRIPTION
Precludes the need for explicit propagation of `NodeActor.$target` if you don't have any Workers