### PR TITLE
Fix byte count in `NodeAnyTypedArray.withUnsafeMutableRawBytes`

### DIFF
--- a/Sources/NodeAPI/NodeTypedArray.swift
+++ b/Sources/NodeAPI/NodeTypedArray.swift
@@ -72,6 +72,20 @@ public enum NodeTypedArrayKind {
             return napi_biguint64_array
         }
     }
+
+    /// Size in bytes of one element of this typed-array kind.
+    var byteSize: Int {
+        switch self {
+        case .int8, .uint8, .uint8Clamped:
+            return 1
+        case .int16, .uint16:
+            return 2
+        case .int32, .uint32, .float32:
+            return 4
+        case .float64, .int64, .uint64:
+            return 8
+        }
+    }
 }
 
 public protocol NodeTypedArrayElement {
@@ -172,11 +186,13 @@ public class NodeAnyTypedArray: NodeObject {
 
     public final func withUnsafeMutableRawBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> T) throws -> T {
         let env = base.environment
+        var type = napi_int8_array
         var data: UnsafeMutableRawPointer?
-        var count = 0
-        try env.check(napi_get_typedarray_info(env.raw, base.rawValue(), nil, &count, &data, nil, nil))
-        // TODO: Do we need to advance `data` by `offset`/a multiple of offset?
-        return try body(UnsafeMutableRawBufferPointer(start: data, count: count))
+        var length = 0
+        try env.check(napi_get_typedarray_info(env.raw, base.rawValue(), &type, &length, &data, nil, nil))
+        // `napi_get_typedarray_info` returns the *element* count in `length`, not the byte count.
+        let byteCount = try length * NodeTypedArrayKind(raw: type).byteSize
+        return try body(UnsafeMutableRawBufferPointer(start: data, count: byteCount))
     }
 
 }


### PR DESCRIPTION
## Summary

`NodeAnyTypedArray.withUnsafeMutableRawBytes` currently passes the `length` value returned by `napi_get_typedarray_info` straight into `UnsafeMutableRawBufferPointer(start:count:)`. Per the [Node-API docs](https://nodejs.org/api/n-api.html#napi-get-typedarray-info), that value is the *element* count of the typed array, not its byte count. The two only coincide for `Int8` / `UInt8` / `Uint8Clamped` arrays.

For every other typed-array kind, the returned raw buffer is silently truncated. This is particularly visible through `NodeTypedArray<Element>.withUnsafeMutableBytes`, which calls `bindMemory(to: Element.self)` on the returned raw buffer: the resulting `UnsafeMutableBufferPointer<Element>` reports a count divided by `MemoryLayout<Element>.size`, so callers only see a fraction of the actual elements (and any reads/writes beyond that fraction are silently skipped).

## Fix

- Query the typed-array kind from `napi_get_typedarray_info` (instead of passing `nil` for the `type` out-parameter).
- Multiply the returned element count by the per-element byte size to get the real byte count.
- Hand back an `UnsafeMutableRawBufferPointer` that covers the entire typed array.

A new `byteSize` property on `NodeTypedArrayKind` centralises the element-size mapping and mirrors the existing `raw` property.

## Repro

```swift
let array = try NodeTypedArray<Float>(for: buffer, count: 1024)
try array.withUnsafeMutableBytes { buf in
    print(buf.count) // before: 256, after: 1024
}
```

## Notes

- No behaviour change for `Int8` / `UInt8` / `Uint8Clamped` arrays.
- The pre-existing `// TODO: Do we need to advance data by offset/a multiple of offset?` is removed; `napi_get_typedarray_info` already returns `data` adjusted by the byte offset, per the Node-API spec.